### PR TITLE
Use most specific failure

### DIFF
--- a/lib/d-parse/parsers/combinators/alt.rb
+++ b/lib/d-parse/parsers/combinators/alt.rb
@@ -16,21 +16,21 @@ module DParse
         "alt(#{@parsers.map(&:inspect).join(',')})"
       end
 
+      private
+
       def best(a, b)
-        case a
-        when DParse::Success
-          a
-        when DParse::Failure
-          case b
-          when DParse::Success
-            b
-          when DParse::Failure
-            if a.pos.index > b.pos.index
-              a
-            else
-              b
-            end
-          end
+        successes, failures = [a, b].partition { |pa| pa.is_a?(DParse::Success) }
+
+        best_success = successes.max_by { |r| r.pos.index }
+        best_failure = failures.max_by { |r| r.pos.index }
+
+        case successes.size
+        when 2
+          best_success
+        when 1
+          best_success.with_best_failure(best_failure)
+        when 0
+          best_failure
         end
       end
     end

--- a/lib/d-parse/parsers/combinators/repeat.rb
+++ b/lib/d-parse/parsers/combinators/repeat.rb
@@ -7,22 +7,35 @@ module DParse
 
       def read(input, pos)
         prev_res = Success.new(input, pos, data: [])
+        best_failure = nil
+
         loop do
           new_res = @parser.read(input, prev_res.pos)
+          best_failure = find_best_failure(best_failure, new_res)
 
-          return prev_res if prev_res.pos.index == new_res.pos.index
+          if prev_res.pos.index == new_res.pos.index
+            return prev_res.with_best_failure(best_failure)
+          end
 
           case new_res
           when Success
             prev_res = new_res.map { |d| prev_res.data + [d] }
           else
-            return prev_res
+            return prev_res.with_best_failure(best_failure)
           end
         end
       end
 
       def inspect
         "repeat(#{@parser})"
+      end
+
+      private
+
+      def find_best_failure(*results)
+        results
+          .select { |r| r.is_a?(DParse::Failure) }
+          .max_by { |r| r.pos.index }
       end
     end
   end

--- a/lib/d-parse/parsers/combinators/seq.rb
+++ b/lib/d-parse/parsers/combinators/seq.rb
@@ -11,7 +11,8 @@ module DParse
         @parsers.reduce(Success.new(input, pos, data: [])) do |res, parser|
           case res
           when Success
-            parser.read(input, res.pos).map { |d| res.data + [d] }
+            new_res = parser.read(input, res.pos).map { |d| res.data + [d] }
+            with_best_failure(new_res, res)
           when Failure
             res
           end
@@ -20,6 +21,28 @@ module DParse
 
       def inspect
         "seq(#{@parsers.map(&:inspect).join(',')})"
+      end
+
+      private
+
+      # Returns a Success or Failure that most accurately describes the
+      # failure, meaning the result that has the highest position.
+      def with_best_failure(new_res, res)
+        results = [new_res, res]
+        results += [new_res.best_failure] if new_res.is_a?(Success)
+        results += [res.best_failure] if res.is_a?(Success)
+
+        best_failure =
+          results
+          .select { |r| r.is_a?(DParse::Failure) }
+          .max_by { |r| r.pos.index }
+
+        case new_res
+        when Success
+          new_res.with_best_failure(best_failure)
+        when Failure
+          best_failure
+        end
       end
     end
   end

--- a/lib/d-parse/parsers/modifiers/map.rb
+++ b/lib/d-parse/parsers/modifiers/map.rb
@@ -10,7 +10,7 @@ module DParse
         res = @parser.read(input, pos)
         case res
         when Success
-          Success.new(input, res.pos, data: @block.call(res.data, res, pos))
+          Success.new(input, res.pos, data: @block.call(res.data, res, pos), best_failure: res.best_failure)
         when Failure
           res
         end

--- a/lib/d-parse/success.rb
+++ b/lib/d-parse/success.rb
@@ -3,19 +3,25 @@ module DParse
     attr_reader :input
     attr_reader :pos
     attr_reader :data
+    attr_reader :best_failure
 
-    def initialize(input, pos, data: nil)
+    def initialize(input, pos, data: nil, best_failure: nil)
       @input = input
       @pos = pos
       @data = data
+      @best_failure = best_failure
     end
 
     def map
-      self.class.new(@input, @pos, data: yield(@data))
+      self.class.new(@input, @pos, data: yield(@data), best_failure: @best_failure)
+    end
+
+    def with_best_failure(failure)
+      self.class.new(@input, @pos, data: @data, best_failure: failure)
     end
 
     def to_s
-      "Success(#{@pos}; #{@data})"
+      "Success(#{@pos}; #{@data}#{@best_failure ? '; best failure = ' + best_failure.inspect : ''})"
     end
 
     def success?

--- a/samples/parse-errortest
+++ b/samples/parse-errortest
@@ -3,18 +3,43 @@
 require 'd-parse'
 require 'pp'
 
-data = <<EOS
-first_name,last_name,age
-Denis,Defreyne,29
-EOS
+module MyGrammar
+  extend DParse::DSL
 
-include DParse::DSL
+  LETTER =
+    describe(alt(*('a'..'z').map { |c| char(c) }), 'letter')
 
-parser =
-  alt(
-    string('Hello!'),
-    string('Hello, world!'),
-    string('Hello… ?'),
-  )
+  IDENTIFIER =
+    describe(
+      repeat(LETTER).capture,
+      'identifier',
+    )
 
-puts parser.apply('Hello, what?').pretty_message
+  FUNDEF =
+    seq(
+      describe(IDENTIFIER, 'identifier'),
+      eof,
+    )
+
+  PARSER =
+    alt(
+      string('Hello!'),
+      string('Hello, world!'),
+      string('Hello… ?'),
+    )
+
+  TESTB =
+    seq(
+      alt(
+        seq(string("a+a").capture),
+        seq(string("a").capture),
+      ),
+      eof,
+    )
+end
+
+puts MyGrammar::PARSER.apply('Hello, what?').pretty_message
+puts
+puts MyGrammar::FUNDEF.apply('foo3a').pretty_message
+puts
+puts MyGrammar::TESTB.apply('a+').pretty_message

--- a/spec/d-parse/parsers/alt_spec.rb
+++ b/spec/d-parse/parsers/alt_spec.rb
@@ -6,8 +6,8 @@ describe DParse::Parsers::Alt do
   example { expect(parser).to parse('Hello').up_to(5).line(0).column(5) }
   example { expect(parser).to parse('Goodbye').up_to(7).line(0).column(7) }
 
-  example { expect(parser).not_to parse('').and_fail_at(0).line(0).column(0).with_failure('expected \'G\'') }
-  example { expect(parser).not_to parse('Wilkommen').and_fail_at(0).line(0).column(0).with_failure('expected \'G\'') }
+  example { expect(parser).not_to parse('').and_fail_at(0).line(0).column(0).with_failure('expected \'H\'') }
+  example { expect(parser).not_to parse('Wilkommen').and_fail_at(0).line(0).column(0).with_failure('expected \'H\'') }
   example { expect(parser).not_to parse('Hallo').and_fail_at(1).line(0).column(1).with_failure('expected \'e\'') }
   example { expect(parser).not_to parse('Hellenistic period').and_fail_at(4).line(0).column(4).with_failure('expected \'o\'') }
 
@@ -18,5 +18,31 @@ describe DParse::Parsers::Alt do
     let(:b) { DParse::Parsers::Char.new('b') }
 
     it { is_expected.to eql('alt(char("a"),char("b"))') }
+  end
+
+  context 'ambiguous parsers' do
+    let(:a) { double('parser') }
+    let(:b) { double('parser') }
+
+    before do
+      expect(a).to receive(:read).and_return(DParse::Failure.new('…', DParse::Position.new(index: 10, line: 0, column: 10)))
+      expect(b).to receive(:read).and_return(DParse::Failure.new('…', DParse::Position.new(index: 20, line: 0, column: 20)))
+    end
+
+    context 'shortest first' do
+      let(:parser) { described_class.new(a, b) }
+
+      it 'picks the most specific failure' do
+        expect(parser).not_to parse('…').and_fail_at(20).line(0).column(20)
+      end
+    end
+
+    context 'longest first' do
+      let(:parser) { described_class.new(b, a) }
+
+      it 'picks the most specific failure' do
+        expect(parser).not_to parse('…').and_fail_at(20).line(0).column(20)
+      end
+    end
   end
 end

--- a/spec/d-parse/parsers/map_spec.rb
+++ b/spec/d-parse/parsers/map_spec.rb
@@ -1,0 +1,54 @@
+describe DParse::Parsers::Map do
+  let(:inner_parser) { double(:parser) }
+  let(:parser) { described_class.new(inner_parser) { |data, res, orig_pos| [:mapped, data, res.class.to_s, orig_pos.index] } }
+
+  describe '#apply / #read' do
+    subject { parser.apply('a') }
+
+    context 'success' do
+      before do
+        expect(inner_parser).to receive(:read).and_return(
+          DParse::Success.new(
+            '…',
+            DParse::Position.new(index: 10, line: 2, column: 3),
+            best_failure: DParse::Failure.new(
+              '…',
+              DParse::Position.new(index: 20, line: 4, column: 6),
+            ),
+          ),
+        )
+      end
+
+      it 'retains successness' do
+        expect(subject).to be_a(DParse::Success)
+      end
+
+      it 'retains position' do
+        expect(subject.pos.index).to eql(10)
+        expect(subject.pos.line).to eql(2)
+        expect(subject.pos.column).to eql(3)
+      end
+
+      it 'maps data' do
+        expect(subject.data).to eql([:mapped, nil, 'DParse::Success', 0])
+      end
+
+      it 'retains best_failure' do
+        expect(subject.best_failure).to be_a(DParse::Failure)
+        expect(subject.best_failure.pos.index).to eql(20)
+        expect(subject.best_failure.pos.line).to eql(4)
+        expect(subject.best_failure.pos.column).to eql(6)
+      end
+    end
+  end
+
+  describe '#inspect' do
+    subject { parser.inspect }
+
+    before do
+      expect(inner_parser).to receive(:inspect).and_return('test_parser()')
+    end
+
+    it { is_expected.to eql('map(test_parser(), <proc>)') }
+  end
+end

--- a/spec/d-parse/parsers/repeat_spec.rb
+++ b/spec/d-parse/parsers/repeat_spec.rb
@@ -16,4 +16,25 @@ describe DParse::Parsers::Repeat do
 
     it { is_expected.to eql('repeat(char("a"))') }
   end
+
+  context 'successes with associated failures' do
+    let(:parser) { described_class.new(DParse::Parsers::String.new('hello')) }
+
+    it 'picks the most specific failure' do
+      expect(parser.apply('hell')).to be_a(DParse::Success)
+      expect(parser.apply('hell').pos.index).to eql(0)
+      expect(parser.apply('hell').best_failure).to be_a(DParse::Failure)
+      expect(parser.apply('hell').best_failure.pos.index).to eql(4)
+
+      expect(parser.apply('hello')).to be_a(DParse::Success)
+      expect(parser.apply('hello').pos.index).to eql(5)
+      expect(parser.apply('hello').best_failure).to be_a(DParse::Failure)
+      expect(parser.apply('hello').best_failure.pos.index).to eql(5)
+
+      expect(parser.apply('helloh')).to be_a(DParse::Success)
+      expect(parser.apply('helloh').pos.index).to eql(5)
+      expect(parser.apply('helloh').best_failure).to be_a(DParse::Failure)
+      expect(parser.apply('helloh').best_failure.pos.index).to eql(6)
+    end
+  end
 end


### PR DESCRIPTION
Sequence and alternation parsers will now return the most specific failure, i.e. the failure with the highest position. This improves error reporting.

For example, given a choice between `a` and `a+a`, the string `"a+"` will be parsed favouring `a+a`:

```
[D*Parse] expected 'a' at line 1, column 3
[D*Parse]
[D*Parse] a+
[D*Parse]   ↑
```

Previously, this would return a failure at the position before that, expecting an end of file:

```
[D*Parse] expected end of file at line 1, column 2
[D*Parse]
[D*Parse] a+
[D*Parse]  ↑
```